### PR TITLE
Bumped failing to compile dependencies and updated implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,9 +263,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitvec"
-version = "0.22.3"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5237f00a8c86130a0cc317830e558b966dd7850d48a953d998c813f01a41b527"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
 dependencies = [
  "funty",
  "radium",
@@ -314,11 +314,26 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14072e323786a34a18e1bf1ef8940fff0537cc45f1f35ad96d4921008c18a88a"
 dependencies = [
- "digest 0.9.0",
- "ff",
- "group",
+ "ff 0.10.1",
+ "group 0.10.0",
  "heapless",
- "pairing",
+ "rand_core 0.6.3",
+ "serde",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "bls12_381_plus"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c681aa947677ec0c5ccfa6f14c0dd039ddbaa7b12952bf146bd5226a5f9880"
+dependencies = [
+ "digest 0.9.0",
+ "ff 0.12.1",
+ "group 0.12.1",
+ "heapless",
+ "pairing 0.22.0",
  "rand_core 0.6.3",
  "serde",
  "subtle",
@@ -919,6 +934,16 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0f40b2dcd8bc322217a5f6559ae5f9e9d1de202a2ecee2e9eafcbece7562a4f"
 dependencies = [
+ "rand_core 0.6.3",
+ "subtle",
+]
+
+[[package]]
+name = "ff"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+dependencies = [
  "bitvec",
  "rand_core 0.6.3",
  "subtle",
@@ -968,9 +993,9 @@ dependencies = [
 
 [[package]]
 name = "funty"
-version = "1.2.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -1147,7 +1172,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c363a5301b8f153d80747126a04b3c82073b9fe3130571a9d170cacdeaf7912"
 dependencies = [
  "byteorder",
- "ff",
+ "ff 0.10.1",
+ "rand_core 0.6.3",
+ "subtle",
+]
+
+[[package]]
+name = "group"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+dependencies = [
+ "ff 0.12.1",
  "rand_core 0.6.3",
  "subtle",
 ]
@@ -1555,7 +1591,7 @@ name = "ockam"
 version = "0.57.0"
 dependencies = [
  "arrayref",
- "bls12_381_plus",
+ "bls12_381_plus 0.5.2",
  "dyn-clone",
  "hex",
  "ockam_channel",
@@ -1570,7 +1606,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_xorshift",
  "serde",
- "serde-big-array",
+ "serde-big-array 0.3.3",
  "serde_json",
  "sha2",
  "signature_bbs_plus",
@@ -1680,9 +1716,9 @@ dependencies = [
 name = "ockam_identity"
 version = "0.45.0"
 dependencies = [
- "bls12_381_plus",
+ "bls12_381_plus 0.5.2",
  "cfg-if",
- "group",
+ "group 0.10.0",
  "heapless",
  "hex",
  "ockam_channel",
@@ -1696,7 +1732,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_xorshift",
  "serde",
- "serde-big-array",
+ "serde-big-array 0.3.3",
  "serde_json",
  "sha2",
  "signature_bbs_plus",
@@ -1902,7 +1938,16 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7de9d09263c9966e8196fe0380c9dbbc7ea114b5cf371ba29004bc1f9c6db7f3"
 dependencies = [
- "group",
+ "group 0.10.0",
+]
+
+[[package]]
+name = "pairing"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135590d8bdba2b31346f9cd1fb2a912329f5135e832a4f422942eb6ead8b6b3b"
+dependencies = [
+ "group 0.12.1",
 ]
 
 [[package]]
@@ -2050,9 +2095,9 @@ checksum = "e2a38df5b15c8d5c7e8654189744d8e396bddc18ad48041a500ce52d6948941f"
 
 [[package]]
 name = "radium"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -2306,6 +2351,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-big-array"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3323f09a748af288c3dc2474ea6803ee81f118321775bffa3ac8f7e65c5e90e7"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde-xml-rs"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2411,13 +2465,13 @@ name = "signature_bbs_plus"
 version = "0.36.0"
 dependencies = [
  "blake2",
- "bls12_381_plus",
+ "bls12_381_plus 0.5.2",
  "digest 0.9.0",
- "ff",
- "group",
+ "ff 0.10.1",
+ "group 0.10.0",
  "hmac-drbg",
  "managed",
- "pairing",
+ "pairing 0.20.0",
  "rand 0.8.5",
  "rand_core 0.6.3",
  "rand_xorshift",
@@ -2433,11 +2487,11 @@ dependencies = [
 name = "signature_bls"
 version = "0.34.0"
 dependencies = [
- "bls12_381_plus",
- "ff",
- "group",
+ "bls12_381_plus 0.7.0",
+ "ff 0.12.1",
+ "group 0.12.1",
  "hkdf",
- "pairing",
+ "pairing 0.20.0",
  "rand_core 0.6.3",
  "rand_xorshift",
  "serde",
@@ -2452,16 +2506,16 @@ name = "signature_core"
 version = "0.36.0"
 dependencies = [
  "blake2",
- "bls12_381_plus",
+ "bls12_381_plus 0.5.2",
  "digest 0.9.0",
- "ff",
- "group",
+ "ff 0.10.1",
+ "group 0.10.0",
  "hashbrown 0.11.2",
  "heapless",
  "rand 0.8.5",
  "rand_core 0.6.3",
  "serde",
- "serde-big-array",
+ "serde-big-array 0.3.3",
  "serde_json",
  "subtle",
  "typenum",
@@ -2472,13 +2526,13 @@ name = "signature_ps"
 version = "0.34.0"
 dependencies = [
  "blake2",
- "bls12_381_plus",
+ "bls12_381_plus 0.5.2",
  "digest 0.9.0",
- "ff",
- "group",
+ "ff 0.10.1",
+ "group 0.10.0",
  "hkdf",
  "hmac-drbg",
- "pairing",
+ "pairing 0.20.0",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_core 0.6.3",
@@ -3048,16 +3102,16 @@ dependencies = [
 
 [[package]]
 name = "vsss-rs"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f509df857e50af93bea4921d55f66a719d2b5f1f6d066abe7f21800448d09ca"
+checksum = "ad69fa818782f94a087aa4645cb1bd89899765059808c314943ace70fb21092b"
 dependencies = [
- "ff",
- "group",
+ "ff 0.12.1",
+ "group 0.12.1",
  "rand_chacha 0.3.1",
  "rand_core 0.6.3",
  "serde",
- "serde-big-array",
+ "serde-big-array 0.4.1",
  "sha2",
  "zeroize",
 ]
@@ -3199,9 +3253,9 @@ checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "wyz"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "129e027ad65ce1453680623c3fb5163cbf7107bfe1aa32257e7d0e63f9ced188"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]

--- a/implementations/rust/ockam/signature_bls/Cargo.toml
+++ b/implementations/rust/ockam/signature_bls/Cargo.toml
@@ -25,20 +25,20 @@ default = ["alloc"]
 alloc = []
 
 [dependencies]
-bls12_381_plus = { version = "0.5", default-features = false, features = [
+bls12_381_plus = { version = "0.7.0", default-features = false, features = [
     "alloc",
     "hashing",
     "pairings",
 ] }
-ff = { version = "0.10", default-features = false }
-group = "0.10"
+ff = { version = "0.12.0", default-features = false }
+group = "0.12.0"
 hkdf = { version = "0.11", default-features = false }
 pairing = "0.20"
 rand_core = "0.6"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 sha2 = { version = "0.9", default-features = false }
 subtle = { version = "2.4", default-features = false }
-vsss-rs = { version = "1.0.0", default-features = false }
+vsss-rs = { version = "1.5.0", default-features = false }
 zeroize = { version = "1.4.2", features = ["zeroize_derive"] }
 
 [dev-dependencies]

--- a/implementations/rust/ockam/signature_bls/src/proof_of_possession.rs
+++ b/implementations/rust/ockam/signature_bls/src/proof_of_possession.rs
@@ -54,7 +54,7 @@ impl ProofOfPossession {
 
     /// Create a new proof of possession
     pub fn new(sk: &SecretKey) -> Option<Self> {
-        if sk.0.is_zero() {
+        if sk.0.is_zero_vartime() {
             return None;
         }
         let pk = PublicKey::from(sk);

--- a/implementations/rust/ockam/signature_bls/src/proof_of_possession_vt.rs
+++ b/implementations/rust/ockam/signature_bls/src/proof_of_possession_vt.rs
@@ -54,7 +54,7 @@ impl ProofOfPossessionVt {
 
     /// Create a new proof of possession
     pub fn new(sk: &SecretKey) -> Option<Self> {
-        if sk.0.is_zero() {
+        if sk.0.is_zero_vartime() {
             return None;
         }
         let pk = PublicKeyVt::from(sk);

--- a/implementations/rust/ockam/signature_bls/src/signature.rs
+++ b/implementations/rust/ockam/signature_bls/src/signature.rs
@@ -56,7 +56,7 @@ impl Signature {
 
     /// Create a new bls
     pub fn new<B: AsRef<[u8]>>(sk: &SecretKey, msg: B) -> Option<Self> {
-        if sk.0.is_zero() {
+        if sk.0.is_zero_vartime() {
             return None;
         }
         let a = Self::hash_msg(msg.as_ref());

--- a/implementations/rust/ockam/signature_bls/src/signature_vt.rs
+++ b/implementations/rust/ockam/signature_bls/src/signature_vt.rs
@@ -56,7 +56,7 @@ impl SignatureVt {
 
     /// Create a new bls
     pub fn new<B: AsRef<[u8]>>(sk: &SecretKey, msg: B) -> Option<Self> {
-        if sk.0.is_zero() {
+        if sk.0.is_zero_vartime() {
             return None;
         }
         let a = Self::hash_msg(msg.as_ref());


### PR DESCRIPTION
Since funty v1.2.0  version yanked recently - signature_bls is not updated yet with bumped version of ff which depends on bitvec which still depends on funty v1.2.0.